### PR TITLE
customize init script to log to base path that we desire

### DIFF
--- a/src/main/assembly/bin/rmt
+++ b/src/main/assembly/bin/rmt
@@ -31,6 +31,8 @@ esac
 
 lib_dir="$base_dir"/lib
 log_dir="$base_dir"/log
+log_dir=${LOG_BASE_PATH:=$log_dir}
+echo "logging to ${log_dir} base path."
 con_dir="$base_dir"/conf
 
 log_file="$con_dir"/log4j2.xml

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -28,7 +28,7 @@
             <RegexFilter regex=".*socket error.*" onMatch="DENY" onMismatch="ACCEPT"/>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
-                <SizeBasedTriggeringPolicy size="128 MB"/>
+                <SizeBasedTriggeringPolicy size="1024 MB"/>
             </Policies>
         </RollingFile>
     
@@ -39,7 +39,7 @@
             </PatternLayout>
             <Policies>
                 <TimeBasedTriggeringPolicy/>
-                <SizeBasedTriggeringPolicy size="128 MB"/>
+                <SizeBasedTriggeringPolicy size="1024 MB"/>
             </Policies>
         </RollingFile>
     


### PR DESCRIPTION
```
# build executables
mvn clean install -Dmaven.test.skip=true

# set log base directory
export LOG_BASE_PATH=/path/to/directory

# run the executable
cd target/redis-rdb-cli-release/redis-rdb-cli/bin
./rmt <args>
```